### PR TITLE
refactor(s3_utils.rs): update file and io imports to use tokio

### DIFF
--- a/src/utils/s3_utils.rs
+++ b/src/utils/s3_utils.rs
@@ -1,8 +1,8 @@
 use chrono::{Duration, Local, NaiveDateTime};
 use s3::bucket::Bucket;
 use std::error::Error;
-use std::fs::File;
-use std::io::BufReader;
+use tokio::fs::File;
+use tokio::io::BufReader;
 use std::path::Path;
 
 /// Uploads a file to an S3 bucket.
@@ -46,7 +46,7 @@ pub async fn upload_file_to_s3(
 
 
     bucket
-        .put_object_stream(&mut reader, s3_path)
+        .put_object_stream(&mut reader, s3_path.clone())
         .await
         .map_err(|e| format!("Failed to upload file to S3: {}", e))?;
 


### PR DESCRIPTION
- Updated file and io imports from std::fs and std::io to tokio versions to support asynchronous operations.
- Modified the put_object_stream method call to clone the s3_path, ensuring thread safety in asynchronous contexts.